### PR TITLE
Support flat map for streams

### DIFF
--- a/pkg/streams/streams.go
+++ b/pkg/streams/streams.go
@@ -151,6 +151,21 @@ func (r Readable) Reduce(fn ReduceFunc, accumulator T) Readable {
 	return Reduce(r, fn, accumulator)
 }
 
+type FlatMapFunc func(msg T) []interface{}
+
+func FlatMap(in Readable, fn FlatMapFunc) Readable {
+	return in.Transform(func(msg T, out Writable) {
+		slice := fn(msg)
+		for _, value := range slice {
+			out <- value
+		}
+	})
+}
+
+func (r Readable) FlatMap(fn FlatMapFunc) Readable {
+	return FlatMap(r, fn)
+}
+
 func Split(streamCount int, stream Readable) ReadableCollection {
 	rc, wc := NewCollection(streamCount)
 

--- a/pkg/streams/streams_test.go
+++ b/pkg/streams/streams_test.go
@@ -92,6 +92,19 @@ func TestStreams(t *testing.T) {
 				So(result[0], ShouldResemble, []T{0 + (2 * 2) + (4*4 + (6 * 6) + (8 * 8))})
 			})
 
+			Convey("When flat map should return slice with result", func() {
+				flapMapped := in.FlatMap(func(msg T) []interface{} {
+					return []interface{}{msg, msg}
+				})
+
+				result := writeAndReadAllMessages(ReadableCollection{flapMapped}, WritableCollection{out}, func(writer int, out Writable) {
+					out <- 1
+					out <- 2
+				})
+
+				So(result[0], ShouldResemble, []T{1, 1, 2, 2})
+			})
+
 			Convey("When grouping by should return grouped result", func() {
 				type message struct {
 					id    int64


### PR DESCRIPTION
Makes it possible to for example map a field of a stream message and return a new stream of slices of that field.