### PR TITLE
Fix nil pointer panic

### DIFF
--- a/pkg/githubstats/release_annotation.go
+++ b/pkg/githubstats/release_annotation.go
@@ -46,7 +46,11 @@ func (p *ReleaseAnnotationProjections) init(id int) projections.ProjectionState 
 func (p *ReleaseAnnotationProjections) apply(state *ReleaseAnnotationState, evt *ghevents.Event) {
 	state.Repo = evt.Repo.Name
 	state.Time = *evt.Payload.Release.PublishedAt
-	state.Title = *evt.Payload.Release.Name
+	if evt.Payload.Release.Name != nil {
+		state.Title = *evt.Payload.Release.Name
+	} else {
+		state.Title = ""
+	}
 	state.Tags = evt.Payload.Release.TagName
 	state.Prerelease = evt.Payload.Release.Prerelease || strings.Contains(evt.Payload.Release.TagName, "beta") || strings.Contains(evt.Payload.Release.TagName, "rc")
 	if state.Prerelease {


### PR DESCRIPTION
Fixes the following panic:

```
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/streams/memorybus/memory_bus.go:83 +0x1dd
2021-03-31 07:34:57	
created by github.com/grafana/devtools/pkg/streams/memorybus.(*InMemoryBus).Start.func1
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/streams/memorybus/memory_bus.go:84 +0x51
2021-03-31 07:34:57	
github.com/grafana/devtools/pkg/streams/memorybus.(*InMemoryBus).Start.func1.1(0xc0002ad840, 0xc000202000, 0xc0338b1080, 0xc01127687105e6d0, 0x490eac5df0, 0x10a41a0, 0xc00032c160)
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/streams/projections/engine.go:95 +0x1b4
2021-03-31 07:34:57	
github.com/grafana/devtools/pkg/streams/projections.(*StreamProjection).createSubscriber.func1(0xadc320, 0xc000202000, 0xc0338b1080)
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/streams/projections/partitioning.go:45 +0x170
2021-03-31 07:34:57	
github.com/grafana/devtools/pkg/streams/projections.(*partionedProjection).Run(0xc000295410, 0xc0338b1080, 0x1c, 0xc03950e900, 0x2)
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/streams/projections/projection.go:67 +0x35b
2021-03-31 07:34:57	
github.com/grafana/devtools/pkg/streams/projections.(*projection).callApply(0xc0002932c0, 0x95f5a0, 0xc03f594900, 0x9bd280, 0xc041176a80, 0x0, 0x0, 0x0)
2021-03-31 07:34:57	
	/usr/local/go/src/reflect/value.go:308 +0xa4
2021-03-31 07:34:57	
reflect.Value.Call(0x984820, 0xc000298dc0, 0x13, 0xc0212495f0, 0x2, 0x2, 0x1, 0x2, 0xc000073c78)
2021-03-31 07:34:57	
	/usr/local/go/src/reflect/value.go:447 +0x461
2021-03-31 07:34:57	
reflect.Value.call(0x984820, 0xc000298dc0, 0x13, 0xa23a30, 0x4, 0xc0212495f0, 0x2, 0x2, 0x2, 0xc0212495f0, ...)
2021-03-31 07:34:57	
	/home/marcus/go/src/github.com/grafana/devtools/pkg/githubstats/release_annotation.go:49 +0x93
2021-03-31 07:34:57	
github.com/grafana/devtools/pkg/githubstats.(*ReleaseAnnotationProjections).apply(0xc0000108a0, 0xc03f594900, 0xc041176a80)
2021-03-31 07:34:57	
goroutine 318 [running]:
2021-03-31 07:34:57	

2021-03-31 07:34:57	
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x87c523]
2021-03-31 07:34:57	
panic: runtime error: invalid memory address or nil pointer dereference
```

