### PR TITLE
Use multi-stage Docker builds for compiling executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ UPTODATE := .uptodate
 # Dependencies (i.e. things that go in the image) still need to be explicitly
 # declared.
 %/$(UPTODATE): %/Dockerfile
-	$(SUDO) docker build -t $(IMAGE_PREFIX)$(shell basename $(@D)) $(@D)/
+	$(SUDO) docker build -t $(IMAGE_PREFIX)$(shell basename $(@D)) -f $(@D)/Dockerfile .
 	$(SUDO) docker tag $(IMAGE_PREFIX)$(shell basename $(@D)) $(IMAGE_PREFIX)$(shell basename $(@D)):$(GIT_REVISION)
 	touch $@
 

--- a/cmd/bots/Dockerfile
+++ b/cmd/bots/Dockerfile
@@ -1,4 +1,26 @@
-FROM debian:buster-slim
+# Builder image
+FROM golang:1.12 AS builder
 
-COPY bots /bin/bots
+WORKDIR /build/
+
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./vendor ./vendor
+COPY ./go.mod ./go.sum ./
+
+RUN go build -mod=vendor \
+  -o /build/bots \
+  ./cmd/bots
+
+# Runtime image
+
+FROM debian:buster-slim AS runtime
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+  apt-get install -y ca-certificates
+
+COPY --from=builder /build/bots /bin/bots
+
 ENTRYPOINT [ "/bin/bots" ]
+CMD [ "-help" ]

--- a/cmd/github-archive-parser/Dockerfile
+++ b/cmd/github-archive-parser/Dockerfile
@@ -1,6 +1,26 @@
-FROM debian:buster-slim
+# Builder image
+FROM golang:1.12 AS builder
 
-RUN apt-get update && apt-get install -y ca-certificates
+WORKDIR /build/
 
-COPY github-archive-parser /bin/github-archive-parser
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./vendor ./vendor
+COPY ./go.mod ./go.sum ./
+
+RUN go build -mod=vendor \
+  -o /build/github-archive-parser \
+  ./cmd/github-archive-parser
+
+# Runtime image
+
+FROM debian:buster-slim AS runtime
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+  apt-get install -y ca-certificates
+
+COPY --from=builder /build/github-archive-parser /bin/github-archive-parser
+
 ENTRYPOINT [ "/bin/github-archive-parser" ]
+CMD [ "-help" ]

--- a/cmd/github-event-aggregator/Dockerfile
+++ b/cmd/github-event-aggregator/Dockerfile
@@ -1,6 +1,26 @@
-FROM debian:buster-slim
+# Builder image
+FROM golang:1.12 AS builder
 
-RUN apt-get update && apt-get install -y ca-certificates
+WORKDIR /build/
 
-COPY github-event-aggregator /bin/github-event-aggregator
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./vendor ./vendor
+COPY ./go.mod ./go.sum ./
+
+RUN go build -mod=vendor \
+    -o /build/github-event-aggregator \
+    ./cmd/github-event-aggregator
+
+# Runtime image
+
+FROM debian:buster-slim AS runtime
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+  apt-get install -y ca-certificates
+
+COPY --from=builder /build/github-event-aggregator /bin/github-event-aggregator
+
 ENTRYPOINT [ "/bin/github-event-aggregator" ]
+CMD [ "-help" ]

--- a/cmd/local-gharchive-server/Dockerfile
+++ b/cmd/local-gharchive-server/Dockerfile
@@ -1,6 +1,26 @@
-FROM debian:buster-slim
+# Builder image
+FROM golang:1.12 AS builder
 
-RUN apt-get update && apt-get install -y ca-certificates
+WORKDIR /build/
 
-COPY local-gharchive-server /bin/local-gharchive-server
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./vendor ./vendor
+COPY ./go.mod ./go.sum ./
+
+RUN go build -mod=vendor \
+  -o /build/local-gharchive-server \
+  ./cmd/local-gharchive-server
+
+# Runtime image
+
+FROM debian:buster-slim AS runtime
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+  apt-get install -y ca-certificates
+
+COPY --from=builder /build/local-gharchive-server /bin/local-gharchive-server
+
 ENTRYPOINT [ "/bin/local-gharchive-server" ]
+CMD [ "-help" ]


### PR DESCRIPTION
### What

This PR makes builds use Docker containers for compiling executables via Docker multi-stage builds.

### Why

Compiling in a container ensures that build environment is always consistent with runtime environment.
