### PR TITLE
add primary key to github_event table

### DIFF
--- a/pkg/archive/migrations.go
+++ b/pkg/archive/migrations.go
@@ -6,6 +6,19 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
+type RawSQLMigration struct {
+	migrator.MigrationBase
+	sql string
+}
+
+func NewRawSQLMigration(sql string) *RawSQLMigration {
+	return &RawSQLMigration{sql: sql}
+}
+
+func (m *RawSQLMigration) Sql(dialect migrator.Dialect) string {
+	return m.sql
+}
+
 func InitDatabase(dbType string, connectionString string) (*xorm.Engine, error) {
 	x, err := xorm.NewEngine(dbType, connectionString)
 	x.SetColumnMapper(core.GonicMapper{})
@@ -49,6 +62,10 @@ func InitDatabase(dbType string, connectionString string) (*xorm.Engine, error) 
 	}
 
 	mig.AddMigration("create github event table", migrator.NewAddTableMigration(githubEvent))
+
+	githubEventPkey := NewRawSQLMigration("ALTER TABLE github_event ADD PRIMARY KEY (id)")
+
+	mig.AddMigration("add primary key to github event table", githubEventPkey)
 
 	return x, mig.Start()
 }


### PR DESCRIPTION
fixes #34

I ended up just adding a simple version of the raw sql migration here since I couldn't import a newer version of grafana/grafana and the syntax is the same for both mysql and postgres